### PR TITLE
Add more options

### DIFF
--- a/run_calibrate_camera.py
+++ b/run_calibrate_camera.py
@@ -9,7 +9,7 @@ Usage:
         -grid 9x6 \
         -out fisheye.yaml \
         -framestep 20 \
-        -resolution 640x480
+        --resolution 640x480
         --fisheye
 """
 import argparse
@@ -38,6 +38,9 @@ def main():
     parser.add_argument("-grid", "--grid", default="9x6",
                         help="size of the calibrate grid pattern")
 
+    parser.add_argument("-r", "--resolution", default="640x480",
+                        help="resolution of the camera image")
+
     parser.add_argument("-framestep", type=int, default=20,
                         help="use every nth frame in the video")
 
@@ -64,6 +67,9 @@ def main():
     font = cv2.FONT_HERSHEY_SIMPLEX
     fontscale = 0.6
 
+    resolution_str = args.resolution.split("x")
+    W = int(resolution_str[0])
+    H = int(resolution_str[1])
     grid_size = tuple(int(x) for x in args.grid.split("x"))
     grid_points = np.zeros((1, np.prod(grid_size), 3), np.float32)
     grid_points[0, :, :2] = np.indices(grid_size).T.reshape(-1, 2)
@@ -74,6 +80,7 @@ def main():
     device = args.input
     cap_thread = CaptureThread(device_id=device,
                                flip_method=args.flip,
+                               resolution=(W, H),
                                use_gst=not args.no_gst,
                                )
     buffer_manager = MultiBufferManager()

--- a/run_calibrate_camera.py
+++ b/run_calibrate_camera.py
@@ -123,8 +123,14 @@ def main():
         cv2.imshow("corners", img)
         key = cv2.waitKey(1) & 0xFF
         if key == ord("c"):
-            do_calib = True
-            break
+            print("\nPerforming calibration...\n")
+            N_OK = len(objpoints)
+            if N_OK < 12:
+                print("Less than 12 corners (%d) detected, calibration failed" %(N_OK))
+                continue
+            else:
+                do_calib = True
+                break
 
         elif key == ord("q"):
             quit = True
@@ -136,12 +142,7 @@ def main():
         cv2.destroyAllWindows()
 
     if do_calib:
-        print("\nPerforming calibration...\n")
         N_OK = len(objpoints)
-        if N_OK < 12:
-            print("Less than 12 corners detected, calibration failed")
-            return
-
         K = np.zeros((3, 3))
         D = np.zeros((4, 1))
         rvecs = [np.zeros((1, 1, 3), dtype=np.float64) for _ in range(N_OK)]

--- a/run_calibrate_camera.py
+++ b/run_calibrate_camera.py
@@ -50,6 +50,9 @@ def main():
     parser.add_argument("-flip", "--flip", default=0, type=int,
                         help="flip method of the camera")
 
+    parser.add_argument("--no_gst", action="store_true",
+                        help="set true if not use gstreamer for the camera capture")
+
     args = parser.parse_args()
 
     if not os.path.exists(TARGET_DIR):
@@ -70,7 +73,9 @@ def main():
 
     device = args.input
     cap_thread = CaptureThread(device_id=device,
-                               flip_method=args.flip)
+                               flip_method=args.flip,
+                               use_gst=not args.no_gst,
+                               )
     buffer_manager = MultiBufferManager()
     buffer_manager.bind_thread(cap_thread, buffer_size=8)
     if cap_thread.connect_camera():

--- a/surround_view/capture_thread.py
+++ b/surround_view/capture_thread.py
@@ -14,6 +14,7 @@ class CaptureThread(BaseThread):
                  drop_if_full=True,
                  api_preference=cv2.CAP_GSTREAMER,
                  resolution=None,
+                 use_gst=True,
                  parent=None):
         """
         device_id: device number of the camera.
@@ -26,6 +27,7 @@ class CaptureThread(BaseThread):
         super(CaptureThread, self).__init__(parent)
         self.device_id = device_id
         self.flip_method = flip_method
+        self.use_gst = use_gst
         self.drop_if_full = drop_if_full
         self.api_preference = api_preference
         self.resolution = resolution
@@ -71,8 +73,11 @@ class CaptureThread(BaseThread):
         qDebug("Stopping capture thread...")
 
     def connect_camera(self):
-        options = gstreamer_pipeline(cam_id=self.device_id, flip_method=self.flip_method)
-        self.cap.open(options, self.api_preference)
+        if self.use_gst:
+            options = gstreamer_pipeline(cam_id=self.device_id, flip_method=self.flip_method)
+            self.cap.open(options, self.api_preference)
+        else:
+            self.cap.open(self.device_id)
         # return false if failed to open camera
         if not self.cap.isOpened():
             qDebug("Cannot open camera {}".format(self.device_id))

--- a/surround_view/simple_gui.py
+++ b/surround_view/simple_gui.py
@@ -1,7 +1,7 @@
 import cv2
 import numpy as np
 
-
+# return -1 if user press 'q'. return 1 if user press 'Enter'.
 def display_image(window_title, image):
     cv2.imshow(window_title, image)
     while True:
@@ -13,6 +13,7 @@ def display_image(window_title, image):
         if key == ord("q"):
             return -1
 
+        # 'Enter' key is detected!
         if key == 13:
             return 1
 


### PR DESCRIPTION
1. support '--no_gst' and '--resolution' options.
2. during the calibration, if failed just print error information instead of quit immediately.