### PR TITLE
Modify setting image format before setting resolution

### DIFF
--- a/surround_view/capture_thread.py
+++ b/surround_view/capture_thread.py
@@ -86,18 +86,18 @@ class CaptureThread(BaseThread):
             # try to set camera resolution
             if self.resolution is not None:
                 width, height = self.resolution
+                self.cap.set(cv2.CAP_PROP_FOURCC, cv2.VideoWriter_fourcc(*"MJPG"))
                 self.cap.set(cv2.CAP_PROP_FRAME_WIDTH, width)
                 self.cap.set(cv2.CAP_PROP_FRAME_HEIGHT, height)
-                self.cap.set(cv2.CAP_PROP_FOURCC, cv2.VideoWriter_fourcc(*"MJPG"))
                 # some camera may become closed if the resolution is not supported
                 if not self.cap.isOpened():
                     qDebug("Resolution not supported by camera device: {}".format(self.resolution))
                     return False
             # use the default resolution
             else:
+                self.cap.set(cv2.CAP_PROP_FOURCC, cv2.VideoWriter_fourcc(*"MJPG"))
                 width = int(self.cap.get(cv2.CAP_PROP_FRAME_WIDTH))
                 height = int(self.cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
-                self.cap.set(cv2.CAP_PROP_FOURCC, cv2.VideoWriter_fourcc(*"MJPG"))
                 self.resolution = (width, height)
 
         return True

--- a/test_cameras.py
+++ b/test_cameras.py
@@ -53,9 +53,9 @@ def init_caps(cam_list, resolution=(1280,720)):
     caps = []
     for iCam in cam_list:
         cap = cv2.VideoCapture(iCam)
+        cap.set(cv2.CAP_PROP_FOURCC, cv2.VideoWriter_fourcc(*"MJPG"))
         cap.set(3, resolution[0])
         cap.set(4, resolution[1])
-        cap.set(cv2.CAP_PROP_FOURCC, cv2.VideoWriter_fourcc(*"MJPG"))
         caps.append(cap)
 
     return caps


### PR DESCRIPTION
Modify the image format setting before setting the resolution. If it is set after the resolution, it will not work.